### PR TITLE
fix(perf): reduce CPU cache pressure during writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,7 @@ new tag pushed in this batch:
 - Update README.md
 - Add byte order debug
 - Reduce test for miri
-- Remove uneeded script
+- Remove unneeded script
 - Test cases
 - Migrate config .github/renovate.json ([#155](https://github.com/zzau13/v_escape/issues/155))
 - Create FUNDING.yml
@@ -397,7 +397,7 @@ Signed-off-by: dependabot[bot] <support@github.com>
 - Update README
 - Bump version to 0.3.2
 - Fix avoid double test
-- Add actvate mode selection to sse
+- Add activate mode selection to sse
 - Add loop m256_64
 - Fix nom macro choice
 - Add v_latexescape

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/zzau13/v_escape"
 default = ["std", "bytes", "string", "fmt"]
 # The 'std' feature permits the memchr crate to use the standard library. This
 # permits this crate to use runtime CPU feature detection to automatically
-# accelerate searching via vector instructions. Without the standard library,
+# speed up searching via vector instructions. Without the standard library,
 # this automatic detection is not possible.
 std = ["alloc"]
 
@@ -25,13 +25,16 @@ std = ["alloc"]
 alloc = []
 
 # The 'string' feature enables the `escape_string` function.
-string = []
+string = ["alloc"]
 
 # The 'fmt' feature enables the `escape_fmt` function.
 fmt = []
 
 # The 'bytes' feature enables the `escape_bytes` function.
-bytes = []
+bytes = ["alloc"]
+
+[dependencies]
+derive-new = "0.7"
 
 [package.metadata.docs.rs]
 features = ["std", "alloc", "string", "fmt", "bytes"]

--- a/base/src/arch/aarch64.rs
+++ b/base/src/arch/aarch64.rs
@@ -1,6 +1,10 @@
 use core::arch::aarch64::int8x16_t;
 
-use crate::{Escapes, EscapesBuilder, Vector, generic::Generic, writer::Writer};
+use crate::{
+    Escapes, EscapesBuilder, Vector,
+    generic::Generic,
+    writer::{Result, Writer},
+};
 
 type NeonVector = int8x16_t;
 
@@ -13,7 +17,10 @@ type NeonVector = int8x16_t;
 /// # Returns
 /// A result indicating success or failure of the escape operation.
 #[inline(always)]
-pub fn escape<E: EscapesBuilder, R>(haystack: &str, writer: impl Writer<R>) -> Result<(), R> {
+pub fn escape<E: EscapesBuilder, const FMT: bool, W: Writer<FMT>>(
+    haystack: &str,
+    writer: W,
+) -> Result<W::Error> {
     let len = haystack.len();
     if len < NeonVector::BYTES {
         return <E::Escapes<()> as Escapes>::byte_byte_escape(haystack, writer);

--- a/base/src/arch/fallback.rs
+++ b/base/src/arch/fallback.rs
@@ -1,4 +1,7 @@
-use crate::{Escapes, EscapesBuilder, writer::Writer};
+use crate::{
+    Escapes, EscapesBuilder,
+    writer::{Result, Writer},
+};
 
 /// A function that performs escape operations using fallback implementation.
 ///
@@ -9,10 +12,10 @@ use crate::{Escapes, EscapesBuilder, writer::Writer};
 /// # Returns
 /// A result indicating success or failure of the escape operation.
 #[inline(always)]
-pub fn escape_fallback<E: EscapesBuilder, R>(
+pub fn escape_fallback<E: EscapesBuilder, const FMT: bool, W: Writer<FMT>>(
     haystack: &str,
-    writer: impl Writer<R>,
-) -> Result<(), R> {
+    writer: W,
+) -> Result<W::Error> {
     // TODO: implement "1.21 Scanning for zero bytes" from Matters Computational by J. Arndt
     // https://www.researchgate.net/publication/267072412_Matters_Computational_Ideas_Algorithms_Source_Code
     // Is not possible with range of bytes, not exist operations for this or are very expensive

--- a/base/src/arch/wasm32.rs
+++ b/base/src/arch/wasm32.rs
@@ -1,6 +1,10 @@
 use core::arch::wasm32::v128;
 
-use crate::{Escapes, EscapesBuilder, Vector, generic::Generic, writer::Writer};
+use crate::{
+    Escapes, EscapesBuilder, Vector,
+    generic::Generic,
+    writer::{Result, Writer},
+};
 
 type WasmVector = v128;
 /// A function that performs escape operations using Wasm SIMD vectorization.
@@ -12,7 +16,10 @@ type WasmVector = v128;
 /// # Returns
 /// A result indicating success or failure of the escape operation.
 #[inline(always)]
-pub fn escape<E: EscapesBuilder, R>(haystack: &str, writer: impl Writer<R>) -> Result<(), R> {
+pub fn escape<E: EscapesBuilder, const FMT: bool, W: Writer<FMT>>(
+    haystack: &str,
+    writer: W,
+) -> Result<W::Error> {
     let len = haystack.len();
     if len < WasmVector::BYTES {
         return <E::Escapes<()> as Escapes>::byte_byte_escape(haystack, writer);

--- a/base/src/arch/x86_64/avx.rs
+++ b/base/src/arch/x86_64/avx.rs
@@ -1,6 +1,10 @@
 use core::arch::x86_64::{__m128i, __m256i};
 
-use crate::{Escapes, EscapesBuilder, Vector, generic::Generic, writer::Writer};
+use crate::{
+    Escapes, EscapesBuilder, Vector,
+    generic::Generic,
+    writer::{Result, Writer},
+};
 
 // Adapted from https://github.com/BurntSushi/memchr/blob/master/src/arch/x86_64/avx2/memchr.rs
 /// Returns true if AVX2 is available in the current environment.
@@ -41,11 +45,14 @@ type SseVector = __m128i;
 /// # Returns
 /// A result indicating success or failure of the escape operation.
 #[inline(always)]
-pub fn escape<E: EscapesBuilder, R>(haystack: &str, mut writer: impl Writer<R>) -> Result<(), R> {
+pub fn escape<E: EscapesBuilder, const FMT: bool, W: Writer<FMT>>(
+    haystack: &str,
+    writer: W,
+) -> Result<W::Error> {
     let len = haystack.len();
     if len < AvxVector::BYTES {
         if len < SseVector::BYTES {
-            return <E::Escapes<()> as Escapes>::byte_byte_escape(haystack, &mut writer);
+            return <E::Escapes<()> as Escapes>::byte_byte_escape(haystack, writer);
         }
         return Generic::new(E::new::<SseVector>()).escape(haystack, writer);
     }

--- a/base/src/arch/x86_64/sse.rs
+++ b/base/src/arch/x86_64/sse.rs
@@ -1,6 +1,10 @@
 use core::arch::x86_64::__m128i;
 
-use crate::{Escapes, EscapesBuilder, Vector, generic::Generic, writer::Writer};
+use crate::{
+    Escapes, EscapesBuilder, Vector,
+    generic::Generic,
+    writer::{Result, Writer},
+};
 
 /// Returns true if SSE2 is available in the current environment.
 pub fn is_available() -> bool {
@@ -25,7 +29,10 @@ type SseVector = __m128i;
 /// # Returns
 /// A result indicating success or failure of the escape operation.
 #[inline(always)]
-pub fn escape<E: EscapesBuilder, R>(haystack: &str, writer: impl Writer<R>) -> Result<(), R> {
+pub fn escape<E: EscapesBuilder, const FMT: bool, W: Writer<FMT>>(
+    haystack: &str,
+    writer: W,
+) -> Result<W::Error> {
     let len = haystack.len();
     if len < SseVector::BYTES {
         return <E::Escapes<()> as Escapes>::byte_byte_escape(haystack, writer);

--- a/base/src/escapes.rs
+++ b/base/src/escapes.rs
@@ -2,7 +2,7 @@ use core::{fmt, str};
 
 use crate::{
     Vector,
-    writer::{Writer, write, write_slice},
+    writer::{Result, Writer, write, write_slice},
 };
 
 /// A builder trait for creating instances of types that implement the `Escapes` trait.
@@ -73,7 +73,10 @@ pub trait Escapes: Copy + fmt::Debug {
     /// # Returns
     /// A `Result` indicating the success or failure of the escape operation.
     #[inline(always)]
-    fn byte_byte_escape<R>(haystack: &str, mut writer: impl Writer<R>) -> Result<(), R> {
+    fn byte_byte_escape<const FMT: bool, W: Writer<FMT>>(
+        haystack: &str,
+        mut writer: W,
+    ) -> Result<W::Error> {
         let len = haystack.len();
         let start = haystack.as_ptr();
         unsafe { Self::byte_byte_escape_raw(start, start.add(len), &mut writer) }
@@ -93,11 +96,11 @@ pub trait Escapes: Copy + fmt::Debug {
     /// This function is unsafe because it operates on raw pointers and assumes
     /// that the memory between `haystack` and `end` is valid and properly aligned.
     #[inline(always)]
-    unsafe fn byte_byte_escape_raw<R>(
+    unsafe fn byte_byte_escape_raw<const FMT: bool, W: Writer<FMT>>(
         start: *const u8,
         end: *const u8,
-        writer: &mut impl Writer<R>,
-    ) -> Result<(), R> {
+        writer: &mut W,
+    ) -> Result<W::Error> {
         unsafe {
             let mut written = start;
             let mut cur = start;

--- a/base/src/generic.rs
+++ b/base/src/generic.rs
@@ -5,7 +5,7 @@ use crate::{
     Escapes, Vector,
     ext::Pointer,
     vector::MoveMask,
-    writer::{Writer, write, write_slice},
+    writer::{Result, Writer, write, write_slice},
 };
 
 /// A generic structure for handling escape sequences in a vectorized manner.
@@ -42,11 +42,11 @@ where
     /// # Returns
     /// A `Result` indicating the success or failure of the escape operation.
     #[inline(always)]
-    pub(crate) fn escape<R>(
+    pub(crate) fn escape<const FMT: bool, W: Writer<FMT>>(
         &mut self,
         haystack: &str,
-        mut writer: impl Writer<R>,
-    ) -> Result<(), R> {
+        mut writer: W,
+    ) -> Result<W::Error> {
         let len = haystack.len();
         let cur = haystack.as_ptr();
         unsafe { self.escape_raw(cur, cur.add(len), &mut writer) }
@@ -66,12 +66,12 @@ where
     /// This function is unsafe because it operates on raw pointers and assumes
     /// that the memory between `start` and `end` is valid and properly aligned.
     #[inline(always)]
-    pub(crate) unsafe fn escape_raw<R>(
+    pub(crate) unsafe fn escape_raw<const FMT: bool, W: Writer<FMT>>(
         &mut self,
         start: *const u8,
         end: *const u8,
-        writer: &mut impl Writer<R>,
-    ) -> Result<(), R> {
+        writer: &mut W,
+    ) -> Result<W::Error> {
         unsafe {
             let len = end.distance(start);
             let mut written = start;
@@ -110,6 +110,7 @@ where
                     let or2 = eqc.or(eqd);
                     let or3 = or1.or(or2);
                     if or3.movemask_will_have_non_zero() {
+                        // TODO: store vector when mask is non-zero
                         self.write_mask(eqa.movemask(), cur, &mut written, writer)?;
                         self.write_mask(
                             eqb.movemask(),
@@ -129,6 +130,17 @@ where
                             &mut written,
                             writer,
                         )?;
+                    } else {
+                        if !FMT {
+                            if written < cur {
+                                write_slice(written, cur, writer)?;
+                            }
+                            writer.write_vector(a);
+                            writer.write_vector(b);
+                            writer.write_vector(c);
+                            writer.write_vector(d);
+                            written = cur.add(Self::LOOP_SIZE);
+                        }
                     }
                     cur = cur.add(Self::LOOP_SIZE);
                 }
@@ -179,13 +191,13 @@ where
     /// This function is unsafe because it operates on raw pointers and assumes
     /// that the memory is valid.
     #[inline(always)]
-    unsafe fn write_step<R>(
+    unsafe fn write_step<const FMT: bool, W: Writer<FMT>>(
         mask: <<E as Escapes>::Vector as Vector>::Mask,
         cur: *const u8,
         offset: usize,
         written: &mut *const u8,
-        writer: &mut impl Writer<R>,
-    ) -> Result<<<E as Escapes>::Vector as Vector>::Mask, R> {
+        writer: &mut W,
+    ) -> core::result::Result<<<E as Escapes>::Vector as Vector>::Mask, W::Error> {
         unsafe {
             let c = E::position(*cur.add(offset));
             if !E::FALSE_POSITIVE || c < E::ESCAPE_LEN {
@@ -217,14 +229,14 @@ where
     /// This function is unsafe because it operates on raw pointers and assumes
     /// that the memory is valid.
     #[inline(always)]
-    unsafe fn write_mask_helper<R>(
+    unsafe fn write_mask_helper<const FMT: bool, W: Writer<FMT>>(
         &mut self,
         mut mask: <<E as Escapes>::Vector as Vector>::Mask,
         cur: *const u8,
         limit: usize,
         written: &mut *const u8,
-        writer: &mut impl Writer<R>,
-    ) -> Result<(), R> {
+        writer: &mut W,
+    ) -> Result<W::Error> {
         unsafe {
             if mask.has_non_zero() {
                 let mut offset = mask.first_offset();
@@ -256,14 +268,14 @@ where
     /// This function is unsafe because it operates on raw pointers and assumes
     /// that the memory is valid.
     #[inline(always)]
-    unsafe fn write_mask_unaligned<R>(
+    unsafe fn write_mask_unaligned<const FMT: bool, W: Writer<FMT>>(
         &mut self,
         mask: <<E as Escapes>::Vector as Vector>::Mask,
         cur: *const u8,
         align: usize,
         written: &mut *const u8,
-        writer: &mut impl Writer<R>,
-    ) -> Result<(), R> {
+        writer: &mut W,
+    ) -> Result<W::Error> {
         unsafe { self.write_mask_helper(mask, cur, align, written, writer) }
     }
 
@@ -282,13 +294,13 @@ where
     /// This function is unsafe because it operates on raw pointers and assumes
     /// that the memory is valid.
     #[inline(always)]
-    unsafe fn write_mask<R>(
+    unsafe fn write_mask<const FMT: bool, W: Writer<FMT>>(
         &mut self,
         mask: <<E as Escapes>::Vector as Vector>::Mask,
         cur: *const u8,
         written: &mut *const u8,
-        writer: &mut impl Writer<R>,
-    ) -> Result<(), R> {
+        writer: &mut W,
+    ) -> Result<W::Error> {
         unsafe { self.write_mask_helper(mask, cur, usize::MAX, written, writer) }
     }
 }

--- a/base/src/generic.rs
+++ b/base/src/generic.rs
@@ -292,7 +292,6 @@ where
                 if !FMT {
                     if *written < cur {
                         write_slice(*written, cur, writer)?;
-                        *written = cur
                     }
                     writer.write_vector(vector);
                     *written = cur.add(E::Vector::BYTES);

--- a/base/src/generic.rs
+++ b/base/src/generic.rs
@@ -110,21 +110,23 @@ where
                     let or2 = eqc.or(eqd);
                     let or3 = or1.or(or2);
                     if or3.movemask_will_have_non_zero() {
-                        // TODO: store vector when mask is non-zero
-                        self.write_mask(eqa.movemask(), cur, &mut written, writer)?;
+                        self.write_mask(a, eqa.movemask(), cur, &mut written, writer)?;
                         self.write_mask(
+                            b,
                             eqb.movemask(),
                             cur.add(E::Vector::BYTES),
                             &mut written,
                             writer,
                         )?;
                         self.write_mask(
+                            c,
                             eqc.movemask(),
                             cur.add(E::Vector::BYTES * 2),
                             &mut written,
                             writer,
                         )?;
                         self.write_mask(
+                            d,
                             eqd.movemask(),
                             cur.add(E::Vector::BYTES * 3),
                             &mut written,
@@ -151,20 +153,21 @@ where
                 let v = E::Vector::load_aligned(cur);
                 let mask = self.escapes.masking(v).movemask();
 
-                self.write_mask(mask, cur, &mut written, writer)?;
+                self.write_mask(v, mask, cur, &mut written, writer)?;
                 cur = cur.add(E::Vector::BYTES);
             }
 
             // Handle any remaining bytes that are less than a full vector's worth.
             if cur < end {
                 debug_assert!(end.distance(cur) < E::Vector::BYTES);
-                let rest = (E::Vector::BYTES - end.distance(cur)) as u32;
-                let start = cur.sub(E::Vector::BYTES - end.distance(cur));
+                let remaining = end.distance(cur);
+                let rest = (E::Vector::BYTES - remaining) as u32;
+                let start = cur.sub(E::Vector::BYTES - remaining);
                 debug_assert_eq!(end.distance(start), E::Vector::BYTES);
                 let x = E::Vector::load_unaligned(start);
                 let mask = self.escapes.masking(x).movemask().shr(rest);
 
-                self.write_mask(mask, cur, &mut written, writer)?;
+                self.write_mask_unaligned(mask, cur, remaining, &mut written, writer)?;
             }
 
             if written < end {
@@ -213,45 +216,6 @@ where
         }
     }
 
-    /// A helper function to write the escape mask, handling both aligned and unaligned data.
-    ///
-    /// # Parameters
-    /// - `mask`: The mask indicating which bytes need to be escaped.
-    /// - `cur`: The current pointer in the data.
-    /// - `limit`: The limit up to which the mask should be processed.
-    /// - `written`: A mutable reference to the pointer indicating the last written position.
-    /// - `writer`: The function to write the escaped output.
-    ///
-    /// # Returns
-    /// A `Result` indicating the success or failure of the write operation.
-    ///
-    /// # Safety
-    /// This function is unsafe because it operates on raw pointers and assumes
-    /// that the memory is valid.
-    #[inline(always)]
-    unsafe fn write_mask_helper<const FMT: bool, W: Writer<FMT>>(
-        &mut self,
-        mut mask: <<E as Escapes>::Vector as Vector>::Mask,
-        cur: *const u8,
-        limit: usize,
-        written: &mut *const u8,
-        writer: &mut W,
-    ) -> Result<W::Error> {
-        unsafe {
-            if mask.has_non_zero() {
-                let mut offset = mask.first_offset();
-                while offset < limit {
-                    mask = Self::write_step(mask, cur, offset, written, writer)?;
-                    if !mask.has_non_zero() {
-                        break;
-                    }
-                    offset = mask.first_offset();
-                }
-            }
-            Ok(())
-        }
-    }
-
     /// Writes the escape mask for unaligned data.
     ///
     /// # Parameters
@@ -270,13 +234,25 @@ where
     #[inline(always)]
     unsafe fn write_mask_unaligned<const FMT: bool, W: Writer<FMT>>(
         &mut self,
-        mask: <<E as Escapes>::Vector as Vector>::Mask,
+        mut mask: <<E as Escapes>::Vector as Vector>::Mask,
         cur: *const u8,
         align: usize,
         written: &mut *const u8,
         writer: &mut W,
     ) -> Result<W::Error> {
-        unsafe { self.write_mask_helper(mask, cur, align, written, writer) }
+        unsafe {
+            if mask.has_non_zero() {
+                let mut offset = mask.first_offset();
+                while offset < align {
+                    mask = Self::write_step(mask, cur, offset, written, writer)?;
+                    if !mask.has_non_zero() {
+                        break;
+                    }
+                    offset = mask.first_offset();
+                }
+            }
+            Ok(())
+        }
     }
 
     /// Writes the escape mask for aligned data.
@@ -296,11 +272,33 @@ where
     #[inline(always)]
     unsafe fn write_mask<const FMT: bool, W: Writer<FMT>>(
         &mut self,
-        mask: <<E as Escapes>::Vector as Vector>::Mask,
+        vector: <E as Escapes>::Vector,
+        mut mask: <<E as Escapes>::Vector as Vector>::Mask,
         cur: *const u8,
         written: &mut *const u8,
         writer: &mut W,
     ) -> Result<W::Error> {
-        unsafe { self.write_mask_helper(mask, cur, usize::MAX, written, writer) }
+        unsafe {
+            if mask.has_non_zero() {
+                let mut offset = mask.first_offset();
+                loop {
+                    mask = Self::write_step(mask, cur, offset, written, writer)?;
+                    if !mask.has_non_zero() {
+                        break;
+                    }
+                    offset = mask.first_offset();
+                }
+            } else {
+                if !FMT {
+                    if *written < cur {
+                        write_slice(*written, cur, writer)?;
+                        *written = cur
+                    }
+                    writer.write_vector(vector);
+                    *written = cur.add(E::Vector::BYTES);
+                }
+            }
+            Ok(())
+        }
     }
 }

--- a/base/src/lib.rs
+++ b/base/src/lib.rs
@@ -92,7 +92,8 @@ mod ext;
 mod generic;
 mod vector;
 #[macro_use]
-mod writer;
+/// A module for writer functions
+pub mod writer;
 
 pub use escapes::{Escapes, EscapesBuilder};
 pub use vector::Vector;

--- a/base/src/vector.rs
+++ b/base/src/vector.rs
@@ -299,6 +299,7 @@ mod x86sse2 {
             unsafe { _mm_loadu_si128(data as *const __m128i) }
         }
 
+        #[inline(always)]
         unsafe fn store(self, dst: *mut u8) {
             unsafe { _mm_storeu_si128(dst as *mut __m128i, self) }
         }

--- a/base/src/vector.rs
+++ b/base/src/vector.rs
@@ -1,16 +1,16 @@
 // Adapted from https://github.com/BurntSushi/memchr/blob/master/src/vector.rs
 /// A trait for describing vector operations used by vectorized searchers.
 ///
-/// The trait is highly constrained to low level vector operations needed.
+/// The trait is highly constrained to low-level vector operations needed.
 /// In general, it was invented mostly to be generic over x86's __m128i and
-/// __m256i types. At time of writing, it also supports wasm and aarch64
+/// __m256i types. At the time of writing, it supports wasm and aarch64
 /// 128-bit vector types as well.
 ///
 /// # Safety
 ///
 /// All methods are not safe since they are intended to be implemented using
 /// vendor intrinsics, which are also not safe. Callers must ensure that the
-/// appropriate target features are enabled in the calling function, and that
+/// appropriate target features are enabled in the calling function and that
 /// the current CPU supports them. All implementations should avoid marking the
 /// routines with #\[target_feature\] and instead mark them as #[\inline(always)\]
 /// to ensure they get appropriately inlined. (inline(always) cannot be used
@@ -50,6 +50,13 @@ pub trait Vector: Copy + core::fmt::Debug {
     /// Callers must guarantee that at least `BYTES` bytes are readable from
     /// `data`.
     unsafe fn load_unaligned(data: *const u8) -> Self;
+
+    /// Store the vector to the given pointer. The pointer does not need to be aligned.
+    ///
+    /// # Safety
+    ///
+    /// Callers must guarantee that at least `BYTES` bytes are writable to `data`.
+    unsafe fn store(self, data: *mut u8);
 
     /// Convert the vector to a mask.
     fn movemask(self) -> Self::Mask;
@@ -166,6 +173,12 @@ impl MoveMask for SensibleMoveMask {
         self.0 != 0
     }
 
+    fn shr(self, rhs: u32) -> Self {
+        // Endianness is not relevant here because the mask always uses
+        // first_offset to compute the offset.
+        SensibleMoveMask(self.0.wrapping_shr(rhs))
+    }
+
     #[inline(always)]
     fn clear_least_significant_bit(self) -> SensibleMoveMask {
         SensibleMoveMask(self.0 & (self.0 - 1))
@@ -180,12 +193,6 @@ impl MoveMask for SensibleMoveMask {
         // That position corresponds to the number of zeros after the least
         // significant bit.
         self.get_for_offset().trailing_zeros() as usize
-    }
-
-    fn shr(self, rhs: u32) -> Self {
-        // Endianness is not relevant here because the mask always uses
-        // first_offset to compute the offset.
-        SensibleMoveMask(self.0.wrapping_shr(rhs))
     }
 }
 
@@ -209,6 +216,10 @@ impl Vector for () {
 
     #[inline(always)]
     unsafe fn load_unaligned(_data: *const u8) -> Self {
+        unreachable!()
+    }
+
+    unsafe fn store(self, _data: *mut u8) {
         unreachable!()
     }
 
@@ -288,6 +299,10 @@ mod x86sse2 {
             unsafe { _mm_loadu_si128(data as *const __m128i) }
         }
 
+        unsafe fn store(self, dst: *mut u8) {
+            unsafe { _mm_storeu_si128(dst as *mut __m128i, self) }
+        }
+
         #[inline(always)]
         fn movemask(self) -> Self::Mask {
             SensibleMoveMask(unsafe { _mm_movemask_epi8(self) } as u32)
@@ -307,7 +322,6 @@ mod x86sse2 {
         fn add(self, vector2: Self) -> Self {
             unsafe { _mm_add_epi8(self, vector2) }
         }
-
         #[inline(always)]
         fn gt(self, vector2: Self) -> Self {
             unsafe { _mm_cmpgt_epi8(self, vector2) }
@@ -341,7 +355,10 @@ mod x86avx2 {
         unsafe fn load_unaligned(data: *const u8) -> Self {
             unsafe { _mm256_loadu_si256(data as *const __m256i) }
         }
-
+        #[inline(always)]
+        unsafe fn store(self, data: *mut u8) {
+            unsafe { _mm256_storeu_si256(data as *mut __m256i, self) }
+        }
         #[inline(always)]
         fn movemask(self) -> Self::Mask {
             SensibleMoveMask(unsafe { _mm256_movemask_epi8(self) } as u32)
@@ -394,6 +411,11 @@ mod aarch64neon {
         #[inline(always)]
         unsafe fn load_unaligned(data: *const u8) -> Self {
             unsafe { vld1q_s8(data as *const i8) }
+        }
+
+        #[inline(always)]
+        fn store(self, data: *mut u8) {
+            unsafe { vst1q_s8(data as *mut i8, self) }
         }
 
         #[inline(always)]
@@ -564,6 +586,11 @@ mod wasm_simd128 {
         #[inline(always)]
         unsafe fn load_unaligned(data: *const u8) -> Self {
             unsafe { v128_load(data.cast()) }
+        }
+
+        #[inline(always)]
+        fn store(self, data: *mut u8) {
+            unsafe { v128_store(data.cast(), self) }
         }
 
         #[inline(always)]

--- a/base/src/vector.rs
+++ b/base/src/vector.rs
@@ -414,7 +414,7 @@ mod aarch64neon {
         }
 
         #[inline(always)]
-        fn store(self, data: *mut u8) {
+        unsafe fn store(self, data: *mut u8) {
             unsafe { vst1q_s8(data as *mut i8, self) }
         }
 
@@ -589,7 +589,7 @@ mod wasm_simd128 {
         }
 
         #[inline(always)]
-        fn store(self, data: *mut u8) {
+        unsafe fn store(self, data: *mut u8) {
             unsafe { v128_store(data.cast(), self) }
         }
 

--- a/base/src/writer.rs
+++ b/base/src/writer.rs
@@ -1,12 +1,8 @@
-use core::{slice, str};
-
+use crate::Vector;
 use crate::ext::Pointer;
+use core::{fmt, result::Result as BResult, slice, str};
+use derive_new::new;
 
-/// A trait for writing strings, defined as a function that takes a string slice
-/// and returns a `Result`.
-///
-/// # Type Parameters
-/// - `R`: The result type for the writer function.
 // TODO: Maybe Writer<T: Add<Output = T>, R> = FnMut(&str) -> Result<T, R>
 // struct Foo;
 // impl core::ops::Add for Foo {
@@ -23,9 +19,88 @@ use crate::ext::Pointer;
 //     }
 // }
 // And implement for &mut dyn core::fmt::Write and &mut dyn core::io::Write
-pub trait Writer<R>: FnMut(&str) -> Result<(), R> {}
 
-impl<R, T: FnMut(&str) -> Result<(), R>> Writer<R> for T {}
+/// A trait for writing strings, defined as a function that takes a string slice
+/// and returns a `Result`.
+///
+/// # Type Parameters
+/// - `R`: The result type for the writer function.
+///
+pub(crate) type Result<Err> = BResult<(), Err>;
+
+/// Sink abstraction that escape routines append output to.
+///
+/// The `FMT` const generic distinguishes byte-oriented writers (`FMT = false`),
+/// which support fast SIMD vector stores via [`Writer::write_vector`], from
+/// formatter-backed writers (`FMT = true`), which only forward string slices to
+/// an underlying [`core::fmt::Write`] and therefore cannot accept raw vector
+/// stores.
+///
+/// Inspired by https://github.com/cloudwego/sonic-rs
+pub trait Writer<const FMT: bool> {
+    /// Error type returned by [`Writer::write_str`].
+    type Error;
+
+    /// Appends a SIMD `vector`'s worth of bytes to the writer.
+    ///
+    /// Only meaningful for byte-oriented writers (`FMT = false`); formatter
+    /// writers must never have this method called on them.
+    fn write_vector<V: Vector>(&mut self, vector: V);
+
+    /// Appends the contents of `src` to the writer.
+    fn write_str(&mut self, src: &str) -> Result<Self::Error>;
+}
+
+/// [`Writer`] implementation that appends bytes to a borrowed [`alloc::vec::Vec`].
+#[cfg(feature = "alloc")]
+#[repr(transparent)]
+#[derive(new)]
+pub struct WriterVec<'a> {
+    inner: &'a mut alloc::vec::Vec<u8>,
+}
+
+#[cfg(feature = "alloc")]
+impl Writer<false> for WriterVec<'_> {
+    type Error = ();
+
+    #[inline(always)]
+    fn write_vector<V: Vector>(&mut self, vector: V) {
+        unsafe {
+            self.inner.reserve(V::BYTES);
+            vector.store(self.inner.as_mut_ptr().add(self.inner.len()));
+            self.inner.set_len(self.inner.len() + V::BYTES);
+        }
+    }
+
+    #[inline(always)]
+    fn write_str(&mut self, src: &str) -> Result<Self::Error> {
+        self.inner.extend_from_slice(src.as_bytes());
+        Ok(())
+    }
+}
+
+/// [`Writer`] implementation that forwards bytes to a [`core::fmt::Formatter`].
+#[cfg(feature = "fmt")]
+#[repr(transparent)]
+#[derive(new)]
+pub struct WriterFMT<'a, 'b> {
+    inner: &'a mut core::fmt::Formatter<'b>,
+}
+
+#[cfg(feature = "fmt")]
+impl Writer<true> for WriterFMT<'_, '_> {
+    type Error = fmt::Error;
+
+    #[inline(always)]
+    fn write_vector<V: Vector>(&mut self, _: V) {
+        unreachable!()
+    }
+
+    #[inline(always)]
+    fn write_str(&mut self, src: &str) -> Result<Self::Error> {
+        self.inner.write_str(src)
+    }
+}
 
 /// Writes a string slice using the writer function.
 ///
@@ -36,8 +111,11 @@ impl<R, T: FnMut(&str) -> Result<(), R>> Writer<R> for T {}
 /// # Returns
 /// A `Result` indicating the success or failure of the write operation.
 #[inline(always)]
-pub(crate) fn write<R>(src: &str, writer: &mut impl Writer<R>) -> Result<(), R> {
-    (writer)(src)
+pub(crate) fn write<const FMT: bool, W: Writer<FMT>>(
+    src: &str,
+    writer: &mut W,
+) -> Result<W::Error> {
+    writer.write_str(src)
 }
 
 /// Writes a slice of bytes as a string using the writer function.
@@ -53,11 +131,11 @@ pub(crate) fn write<R>(src: &str, writer: &mut impl Writer<R>) -> Result<(), R> 
 /// # Safety
 /// This function is unsafe because it assumes that the byte slice is valid UTF-8.
 #[inline(always)]
-pub(crate) unsafe fn write_slice<R>(
+pub(crate) unsafe fn write_slice<const FMT: bool, W: Writer<FMT>>(
     start: *const u8,
     end: *const u8,
-    writer: &mut impl Writer<R>,
-) -> Result<(), R> {
+    writer: &mut W,
+) -> Result<W::Error> {
     unsafe {
         write(
             str::from_utf8_unchecked(slice::from_raw_parts(start, end.distance(start))),
@@ -78,10 +156,10 @@ pub(crate) unsafe fn write_slice<R>(
 #[cfg(feature = "fmt")]
 macro_rules! builder_fmt {
     ($name:ident, $fn:path, $fn_name:ident, $builder:ty) => {
-        fn $name(haystack: &str, buffer: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fn $name<'a>(haystack: &str, buffer: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             use $fn;
-            let writer = |s: &str| buffer.write_str(s);
-            $fn_name::<$builder, _>(haystack, writer)
+            let writer = $crate::writer::WriterFMT::new(buffer);
+            $fn_name::<$builder, _, _>(haystack, writer)
         }
     };
 }
@@ -153,11 +231,14 @@ macro_rules! builder_string {
         /// get rewritten and their replacements.
         pub fn $name(haystack: &str, buffer: &mut String) {
             use $fn;
-            let writer = |s: &str| {
-                buffer.push_str(s);
-                Ok::<(), ()>(())
-            };
-            let _ = $fn_name::<$builder, _>(haystack, writer);
+            // SAFETY: The escape routine only writes valid UTF-8: the input
+            // `haystack` is forwarded verbatim and every replacement emitted
+            // through the escape table is itself valid UTF-8. Therefore the
+            // `String` invariant is upheld after the writer is dropped.
+            let vec = unsafe { buffer.as_mut_vec() };
+            let writer = $crate::writer::WriterVec::new(vec);
+
+            let _ = $fn_name::<$builder, _, _>(haystack, writer);
         }
     };
 }
@@ -201,11 +282,8 @@ macro_rules! builder_bytes {
         /// get rewritten and their replacements.
         pub fn $name(haystack: &str, buffer: &mut Vec<u8>) {
             use $fn;
-            let writer = |s: &str| {
-                buffer.extend_from_slice(s.as_bytes());
-                Ok::<(), ()>(())
-            };
-            let _ = $fn_name::<$builder, _>(haystack, writer);
+            let writer = $crate::writer::WriterVec::new(buffer);
+            let _ = $fn_name::<$builder, _, _>(haystack, writer);
         }
     };
 }

--- a/base/src/writer.rs
+++ b/base/src/writer.rs
@@ -159,7 +159,7 @@ macro_rules! builder_fmt {
         fn $name<'a>(haystack: &str, buffer: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
             use $fn;
             let writer = $crate::writer::WriterFMT::new(buffer);
-            $fn_name::<$builder, _, _>(haystack, writer)
+            $fn_name::<$builder, true, _>(haystack, writer)
         }
     };
 }
@@ -238,7 +238,7 @@ macro_rules! builder_string {
             let vec = unsafe { buffer.as_mut_vec() };
             let writer = $crate::writer::WriterVec::new(vec);
 
-            let _ = $fn_name::<$builder, _, _>(haystack, writer);
+            let _ = $fn_name::<$builder, false, _>(haystack, writer);
         }
     };
 }
@@ -283,7 +283,7 @@ macro_rules! builder_bytes {
         pub fn $name(haystack: &str, buffer: &mut Vec<u8>) {
             use $fn;
             let writer = $crate::writer::WriterVec::new(buffer);
-            let _ = $fn_name::<$builder, _, _>(haystack, writer);
+            let _ = $fn_name::<$builder, false, _>(haystack, writer);
         }
     };
 }

--- a/base/tests/lib.rs
+++ b/base/tests/lib.rs
@@ -1,5 +1,5 @@
 #![cfg(all(feature = "string", feature = "fmt", feature = "bytes"))]
-use v_escape_base::{Escapes, EscapesBuilder, Vector, escape_builder};
+use v_escape_base::{Escapes, EscapesBuilder, Vector, escape_builder, writer::WriterVec};
 
 mod no_false_positive {
     use super::*;
@@ -268,11 +268,7 @@ mod no_false_positive {
     #[test]
     fn test_byte_byte_escape() {
         let mut buffer = String::new();
-        let writer = |s: &str| {
-            buffer.push_str(s);
-            Ok::<(), ()>(())
-        };
-
+        let writer = WriterVec::new(unsafe { buffer.as_mut_vec() });
         let result = Equal::<()>::byte_byte_escape("a", writer);
         assert!(result.is_ok());
         assert_eq!(buffer, "foo");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches the core SIMD escape hot path and rewires the writer abstraction to support raw vector stores, which could introduce subtle correctness/performance regressions across architectures. Also changes feature gating (`string`/`bytes` now require `alloc`) and adds a new dependency.
> 
> **Overview**
> Refactors `v_escape-base`’s output layer from `FnMut(&str)` closures to a const-generic `Writer<FMT>` trait with concrete sinks (`WriterVec` for byte buffers and `WriterFMT` for `core::fmt::Formatter`), enabling **direct SIMD vector stores** into `Vec<u8>`/`String` buffers.
> 
> Updates all escape entry points (fallback + `aarch64`/`wasm32`/`sse`/`avx`) and the generic SIMD loop to use the new writer API and to fast-path mask-free blocks by writing vectors instead of slicing, plus adds `Vector::store` implementations across SIMD backends.
> 
> Also adjusts feature flags so `string`/`bytes` depend on `alloc`, exports the `writer` module publicly, adds `derive-new`, and updates tests/changelog accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd996f52b240cec9f7917733cbc46d57fbb4b1c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->